### PR TITLE
UefiPayloadPkg: Remove FP initialization

### DIFF
--- a/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
+++ b/UefiPayloadPkg/UefiPayloadEntry/UniversalPayloadEntry.c
@@ -470,9 +470,6 @@ _ModuleEntryPoint (
     PrintHob (mHobList);
     );
 
-  // Initialize floating point operating environment to be compliant with UEFI spec.
-  InitializeFloatingPointUnits ();
-
   // Build HOB based on information from Bootloader
   Status = BuildHobs (BootloaderParameter, &DxeFv);
   ASSERT_EFI_ERROR (Status);


### PR DESCRIPTION
According to UPL specification we do not need FP initialization https://universalscalablefirmware.github.io/documentation/

Cc: Gua Guo <gua.guo@intel.com>